### PR TITLE
Fixes Cordova iOS 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ If you do not set this resource, then the SDK will use the default icon for your
 #### iOS compilation details
 Put your generated file GoogleService-Info.plist in the project root folder.
 
-:warning: The plugin will throw an xCode error on Cordova-iOS 4.0.0. Install previous cordova version:
-```Bash
-cordova platform remove ios
-cordova platform add ios@3.9.2 
-```
 
 ##Usage
 
@@ -60,7 +55,7 @@ FCMPlugin.onNotification(
   function(data){
     alert(data.key);
   },
-  successCallback, 
+  successCallback,
   errorCallback
 );
 ```

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -17,7 +17,7 @@
 static NSData *lastPush;
 
 //Method swizzling
-+ (void)load 
++ (void)load
 {
     Method original =  class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
     Method custom =    class_getInstanceMethod(self, @selector(application:customDidFinishLaunchingWithOptions:));
@@ -25,19 +25,18 @@ static NSData *lastPush;
 }
 
 - (BOOL)application:(UIApplication *)application customDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    
+
     [self application:application customDidFinishLaunchingWithOptions:launchOptions];
-    
+
     NSLog(@"DidFinishLaunchingWithOptions");
     // Register for remote notifications
+
+    // iOS 7.1 or earlier
     if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1) {
-        // iOS 7.1 or earlier
-        UIRemoteNotificationType allNotificationTypes =
-        (UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge);
+        UIRemoteNotificationType allNotificationTypes = (UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge);
         [application registerForRemoteNotificationTypes:allNotificationTypes];
     } else {
         // iOS 8 or later
-        // [END_EXCLUDE]
         UIUserNotificationType allNotificationTypes =
         (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
         UIUserNotificationSettings *settings =
@@ -45,7 +44,7 @@ static NSData *lastPush;
         [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
         [[UIApplication sharedApplication] registerForRemoteNotifications];
     }
-    
+
     // [START configure_firebase]
     [FIRApp configure];
     // [END configure_firebase]
@@ -57,15 +56,15 @@ static NSData *lastPush;
 
 // [START receive_message]
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
-fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler 
+fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
     // If you are receiving a notification message while your app is in the background,
     // this callback will not be fired till the user taps on the notification launching the application.
     // TODO: Handle data of notification
-    
+
     // Print message ID.
     NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
-    
+
     // Pring full message.
     NSLog(@"%@", userInfo);
     NSError *error;
@@ -77,32 +76,32 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
         [FCMPlugin.fcmPlugin notifyOfMessage:jsonData];
         // app is in background or in stand by
     }else{
-        NSLog(@"APP WAS CLOSED DURING PUSH RECEPTION Saved data: @", jsonData);
+        NSLog(@"APP WAS CLOSED DURING PUSH RECEPTION Saved data: %@", jsonData);
         lastPush = jsonData;
     }
-    
+
     completionHandler(UIBackgroundFetchResultNoData);
 }
 // [END receive_message]
 
 // [START refresh_token]
-- (void)tokenRefreshNotification:(NSNotification *)notification 
+- (void)tokenRefreshNotification:(NSNotification *)notification
 {
     // Note that this callback will be fired everytime a new token is generated, including the first
     // time. So if you need to retrieve the token as soon as it is available this is where that
     // should be done.
     NSString *refreshedToken = [[FIRInstanceID instanceID] token];
     NSLog(@"InstanceID token: %@", refreshedToken);
-    
+
     // Connect to FCM since connection may have failed when attempted before having a token.
     [self connectToFcm];
-    
+
     // TODO: If necessary send token to appliation server.
 }
 // [END refresh_token]
 
 // [START connect_to_fcm]
-- (void)connectToFcm 
+- (void)connectToFcm
 {
     [[FIRMessaging messaging] connectWithCompletion:^(NSError * _Nullable error) {
         if (error != nil) {
@@ -116,7 +115,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 }
 // [END connect_to_fcm]
 
-- (void)applicationDidBecomeActive:(UIApplication *)application 
+- (void)applicationDidBecomeActive:(UIApplication *)application
 {
     NSLog(@"app become active");
     [FCMPlugin.fcmPlugin appEnterForeground];
@@ -124,9 +123,9 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 }
 
 // [START disconnect_from_fcm]
-- (void)applicationDidEnterBackground:(UIApplication *)application 
+- (void)applicationDidEnterBackground:(UIApplication *)application
 {
-	NSLog(@"app entered background");
+    NSLog(@"app entered background");
     [[FIRMessaging messaging] disconnect];
     [FCMPlugin.fcmPlugin appEnterBackground];
     NSLog(@"Disconnected from FCM");

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -12,8 +12,8 @@
 
 @implementation FCMPlugin
 
-static BOOL *notificatorReceptorReady = NO;
-static BOOL *appInForeground = YES;
+static BOOL notificatorReceptorReady = NO;
+static BOOL appInForeground = YES;
 
 static NSString *notificationCallback = @"FCMPlugin.onNotificationReceived";
 static FCMPlugin *fcmPluginInstance;
@@ -85,7 +85,11 @@ static FCMPlugin *fcmPluginInstance;
     NSString * notifyJS = [NSString stringWithFormat:@"%@(%@);", notificationCallback, JSONString];
     NSLog(@"stringByEvaluatingJavaScriptFromString %@", notifyJS);
     
-    [self.webView stringByEvaluatingJavaScriptFromString:notifyJS];
+    if ([self.webView respondsToSelector:@selector(stringByEvaluatingJavaScriptFromString:)]) {
+        [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:notifyJS];
+    } else {
+        [self.webViewEngine evaluateJavaScript:notifyJS completionHandler:nil];
+    }
 }
 
 -(void) appEnterBackground


### PR DESCRIPTION
* Tested with Cordova 6.2.0 and iOS 4.1.1
* Also tested with `cordova-plugin-wkwebview-engine` 1.0.3 

The big change is to use webviewengine to evaluate the js.
```objectivec
if ([self.webView respondsToSelector:@selector(stringByEvaluatingJavaScriptFromString:)]) {
    [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:notifyJS];
} else {
    [self.webViewEngine evaluateJavaScript:notifyJS completionHandler:nil];
}
```