### PR TITLE
Cordova iOS < 4.0.0

### DIFF
--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -8,6 +8,7 @@
 #import "Firebase.h"
 
 @interface FCMPlugin () {}
+@property (strong) id webViewEngine;
 @end
 
 @implementation FCMPlugin
@@ -97,7 +98,9 @@ static FCMPlugin *fcmPluginInstance;
     if ([self.webView respondsToSelector:@selector(stringByEvaluatingJavaScriptFromString:)]) {
         [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:notifyJS];
     } else {
-        [self.webViewEngine evaluateJavaScript:notifyJS completionHandler:nil];
+#if CORDOVA_VERSION_MIN_REQUIRED >= __CORDOVA_4_0_0
+        [self.webViewEngine performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:notifyJS withObject:nil];
+#endif
     }
 }
 


### PR DESCRIPTION
Adds a webViewEngine to avoid having the error. It is never called or
used in Cordova iOS lower than 4.0.0.

Tested (Cordova iOS version):
* 3.8.0
* 3.9.2
* 4.0.1 (without and without) wkwebview-engine
* 4.1.1 (without and without) wkwebview-engine