### PR TITLE
Background mode push notification

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -54,6 +54,26 @@ static NSData *lastPush;
     return YES;
 }
 
+// [START receive_message in background]
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
+    NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
+    
+    NSError *error;
+    NSDictionary *userInfoMutable = [userInfo mutableCopy];
+    
+    if (application.applicationState != UIApplicationStateActive) {
+        NSLog(@"New method with push callback: %@", userInfo);
+        
+        [userInfoMutable setValue:@(YES) forKey:@"wasTapped"];
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfoMutable
+                                                           options:0
+                                                             error:&error];
+        NSLog(@"APP WAS CLOSED DURING PUSH RECEPTION Saved data: %@", jsonData);
+        lastPush = jsonData;
+    }
+}
+// [END receive_message in background]
+
 // [START receive_message]
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
 fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler


### PR DESCRIPTION
When a push notification is received in background, when tap into it and enter into foreground mode the callback is not fired, and the push notification is not passed into the onNotification callback in typescript.

This is a 5 minute fix that allows the data to be passed into the callback, overriding the method by the author.
With this change both foreground and background pushes work.

Thanks to @gadaxara