### PR TITLE
Support using an alternate notification icon

### DIFF
--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -77,6 +77,14 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                 .setSound(defaultSoundUri)
                 .setContentIntent(pendingIntent);
 
+        int resID = getResources().getIdentifier("notificationIcon" , "drawable", getPackageName());
+        if(resID != 0){
+            notificationBuilder.setSmallIcon(resID);
+        }
+        else{
+            notificationBuilder.setSmallIcon(getApplicationInfo().icon);
+        }
+
         NotificationManager notificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 

--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -70,7 +70,6 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
         Uri defaultSoundUri= RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
-                .setSmallIcon(getApplicationInfo().icon)
                 .setContentTitle(title)
                 .setContentText(messageBody)
                 .setAutoCancel(true)


### PR DESCRIPTION
the change looks for an icon named "notificationIcon" in the drawable folder. if it is not found it defaults to the app icon.