### PR TITLE
add title and body to data array for android

### DIFF
--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -40,7 +40,11 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 			Log.d(TAG, "\tNotification Message: " + remoteMessage.getNotification().getBody());
 		}
 		
-		Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("wasTapped", false);
+        data.put("title", remoteMessage.getNotification().getTitle());
+        data.put("body", remoteMessage.getNotification().getBody());
+
 		data.put("wasTapped", false);
 		for (String key : remoteMessage.getData().keySet()) {
                 Object value = remoteMessage.getData().get(key);


### PR DESCRIPTION
Following the request of a user here https://github.com/fechanique/cordova-plugin-fcm/issues/89#issuecomment-257510815 , i've updated the data array used by android apps for this plugin to include the title and the body in the foreground state.
Hope it helps.