### PR TITLE
Fix Background Notifications When close app with back button [Android]

### DIFF
--- a/src/android/FCMPlugin.java
+++ b/src/android/FCMPlugin.java
@@ -18,16 +18,16 @@ import com.google.firebase.iid.FirebaseInstanceId;
 import java.util.Map;
 
 public class FCMPlugin extends CordovaPlugin {
- 
+
 	private static final String TAG = "FCMPlugin";
-	
+
 	public static CordovaWebView gWebView;
 	public static String notificationCallBack = "FCMPlugin.onNotificationReceived";
 	public static Boolean notificationCallBackReady = false;
 	public static Map<String, Object> lastPush = null;
-	 
+
 	public FCMPlugin() {}
-	
+
 	public void initialize(CordovaInterface cordova, CordovaWebView webView) {
 		super.initialize(cordova, webView);
 		gWebView = webView;
@@ -35,11 +35,18 @@ public class FCMPlugin extends CordovaPlugin {
 		FirebaseMessaging.getInstance().subscribeToTopic("android");
 		FirebaseMessaging.getInstance().subscribeToTopic("all");
 	}
-	 
+
+	@Override
+	public void onDestroy() {
+	    Log.d(TAG, "==> FCMPlugin Destroy");
+	    super.onDestroy();
+	    gWebView = null;
+	}
+
 	public boolean execute(final String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
 
 		Log.d(TAG,"==> FCMPlugin execute: "+ action);
-		
+
 		try{
 			// READY //
 			if (action.equals("ready")) {
@@ -105,13 +112,13 @@ public class FCMPlugin extends CordovaPlugin {
 			callbackContext.error(e.getMessage());
 			return false;
 		}
-		
+
 		//cordova.getThreadPool().execute(new Runnable() {
 		//	public void run() {
 		//	  //
 		//	}
 		//});
-		
+
 		//cordova.getActivity().runOnUiThread(new Runnable() {
         //    public void run() {
         //      //
@@ -119,7 +126,7 @@ public class FCMPlugin extends CordovaPlugin {
         //});
 		return true;
 	}
-	
+
 	public static void sendPushPayload(Map<String, Object> payload) {
 		Log.d(TAG, "==> FCMPlugin sendPushPayload");
 		Log.d(TAG, "\tnotificationCallBackReady: " + notificationCallBackReady);
@@ -136,6 +143,7 @@ public class FCMPlugin extends CordovaPlugin {
 				gWebView.sendJavascript(callBack);
 			}else {
 				Log.d(TAG, "\tView not ready. SAVED NOTIFICATION: " + callBack);
+				payload.put("wasTapped", true);
 				lastPush = payload;
 			}
 		} catch (Exception e) {
@@ -143,4 +151,4 @@ public class FCMPlugin extends CordovaPlugin {
 			lastPush = payload;
 		}
 	}
-} 
+}


### PR DESCRIPTION
  - When the application is closed by pressing the back button, The application is not completely closed.
Then the FCMPluginActivity class is not executed in this case. So the webView var is true and the javascript is not working. I add the destroy event for set webView to false to save the notification in lastpush var.