### PR TITLE
move framework dependency from gradle file to plugin.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.5",
+  "version": "1.1.6",
   "name": "cordova-plugin-fcm",
   "cordova_name": "Cordova FCM Push Plugin",
   "description": "Google Firebase Cloud Messaging Cordova Push Plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-fcm"
-      version="1.1.5">
+      version="1.1.6">
     <name>FCMPlugin</name>
     <description>Cordova FCM Plugin</description>
     <license>Apache 2.0</license>
@@ -62,7 +62,9 @@
             	</feature>
         </config-file>
 		
-	<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
+        <framework src="com.google.gms:google-services:+" />
+        <framework src="com.google.firebase:firebase-core:+" />
+        <framework src="com.google.firebase:firebase-messaging:+" />
 		
         <source-file src="src/android/FCMPlugin.java" target-dir="src/com/gae/scaffolder/plugin" />
 	<source-file src="src/android/MyFirebaseMessagingService.java" target-dir="src/com/gae/scaffolder/plugin" />


### PR DESCRIPTION
Using exact version of dependency will easily cause conflict with other plugins. Using the latest version is a good practice. Gradle file cannot handle it automatically, but cordova can, with plugin.xml. 