### PR TITLE
New function FCMPlugin.ready() to show iOS notifications authorization pop-up.

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.h
+++ b/src/ios/AppDelegate+FCMPlugin.h
@@ -12,6 +12,7 @@
 
 @interface AppDelegate (FCMPlugin)
 
++ (void)register_for_notifications;
 + (NSData*)getLastPush;
 
 @end

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -37,23 +37,9 @@
 static NSData *lastPush;
 NSString *const kGCMMessageIDKey = @"gcm.message_id";
 
-//Method swizzling
-+ (void)load
-{
-    Method original =  class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
-    Method custom =    class_getInstanceMethod(self, @selector(application:customDidFinishLaunchingWithOptions:));
-    method_exchangeImplementations(original, custom);
-}
++ (void)register_for_notifications {
 
-- (BOOL)application:(UIApplication *)application customDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-
-    [self application:application customDidFinishLaunchingWithOptions:launchOptions];
-
-    NSLog(@"DidFinishLaunchingWithOptions");
- 
-    
-    // Register for remote notifications. This shows a permission dialog on first run, to
-    // show the dialog at a more appropriate time move this registration accordingly.
+    // Register for remote notifications. This shows a permission dialog
     if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1) {
         // iOS 7.1 or earlier. Disable the deprecation warnings.
 #pragma clang diagnostic push
@@ -62,7 +48,7 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
         (UIRemoteNotificationTypeSound |
          UIRemoteNotificationTypeAlert |
          UIRemoteNotificationTypeBadge);
-        [application registerForRemoteNotificationTypes:allNotificationTypes];
+        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:allNotificationTypes];
 #pragma clang diagnostic pop
     } else {
         // iOS 8 or later
@@ -98,9 +84,9 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     [FIRApp configure];
     // [END configure_firebase]
     // Add observer for InstanceID token refresh callback.
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)
+		AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+    [[NSNotificationCenter defaultCenter] addObserver:appDelegate selector:@selector(tokenRefreshNotification:)
                                                  name:kFIRInstanceIDTokenRefreshNotification object:nil];
-    return YES;
 }
 
 // [START message_handling]

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -27,6 +27,7 @@ static FCMPlugin *fcmPluginInstance;
 - (void) ready:(CDVInvokedUrlCommand *)command
 {
     NSLog(@"Cordova view ready");
+		[AppDelegate register_for_notifications];
     fcmPluginInstance = self;
     [self.commandDelegate runInBackground:^{
         

--- a/www/FCMPlugin.js
+++ b/www/FCMPlugin.js
@@ -36,10 +36,10 @@ FCMPlugin.prototype.onTokenRefreshReceived = function(token){
 	console.log("Received token refresh")
 	console.log(token)
 }
-// FIRE READY //
-exec(function(result){ console.log("FCMPlugin Ready OK") }, function(result){ console.log("FCMPlugin Ready ERROR") }, "FCMPlugin",'ready',[]);
-
-
+// FIRE READY - SHOW IOS NOTIFICATIONS AUTHORIZATION POP-UP //
+FCMPlugin.prototype.ready = function(){
+	exec(function(result){ console.log("FCMPlugin Ready OK") }, function(result){ console.log("FCMPlugin Ready ERROR") }, "FCMPlugin",'ready',[]);
+}
 
 
 


### PR DESCRIPTION
I've added a new function to the plugin FCMPlugin.ready() that wraps up the code to register for notifications and shows the authorization pop-up in iOS. It should be called before setting the notifications with FCMPlugin.onNotification(). For those of you who also want to let their users know in advance why they want our notifications ;)