### PR TITLE
Added support to show badge count on app icon in supported android devices

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,6 +74,7 @@
 		<source-file src="src/android/MyFirebaseMessagingService.java" target-dir="src/com/gae/scaffolder/plugin" />
 		<source-file src="src/android/MyFirebaseInstanceIDService.java" target-dir="src/com/gae/scaffolder/plugin" />
 		<source-file src="src/android/FCMPluginActivity.java" target-dir="src/com/gae/scaffolder/plugin" />
+		<source-file src="src/android/BadgeHelper.java" target-dir="src/com/gae/scaffolder/plugin" />
     </platform>
 	
     <!-- IOS CONFIGURATION -->

--- a/src/android/BadgeHelper.java
+++ b/src/android/BadgeHelper.java
@@ -1,0 +1,40 @@
+package com.gae.scaffolder.plugin;
+
+import android.content.Context;
+import android.util.Log;
+
+import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+/**
+ * Created by ArindamN on 04/04/2017.
+ */
+public class BadgeHelper {
+    private static String TAG = "FCM_BADGE_HELPER";
+    public final static String CONST_BADGE_KEY = "badge";
+
+    public static void setBadgeCount(String badge, Context ctx){
+        try {
+            //String badge = (String) remoteMessage.get("badge");
+            int badgeCount = 0;
+            if(badge!=null && !badge.isEmpty()){
+                badgeCount = tryParseInt(badge);
+            }
+            if(badgeCount>0)
+            {
+                ShortcutBadger. applyCountOrThrow(ctx, badgeCount);
+                Log.d(TAG, "showBadge worked!");
+            }
+
+        } catch (ShortcutBadgeException e) {
+            Log.e(TAG, "showBadge failed: " + e.getMessage());
+        }
+    }
+    static int tryParseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     dependencies {
         classpath 'com.android.tools.build:gradle:+'
-        classpath 'com.google.gms:google-services:+'
+        classpath 'com.google.gms:google-services:3.0.0'
     }
 }
 // apply plugin: 'com.google.gms.google-services'

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -6,9 +6,12 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:+'
         classpath 'com.google.gms:google-services:+'
-        compile 'me.leolin:ShortcutBadger:1.1.11@aar'
+        
     }
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
 apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+dependencies {
+    compile 'me.leolin:ShortcutBadger:1.1.11@aar'
+}

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:+'
         classpath 'com.google.gms:google-services:+'
+        compile 'me.leolin:ShortcutBadger:1.1.11@aar'
     }
 }
 // apply plugin: 'com.google.gms.google-services'

--- a/src/android/FCMPluginActivity.java
+++ b/src/android/FCMPluginActivity.java
@@ -38,7 +38,8 @@ public class FCMPluginActivity extends Activity {
 				data.put(key, value);
             }
         }
-		
+        
+		BadgeHelper.setBadgeCount((String) data.get(BadgeHelper.CONST_BADGE_KEY), getApplicationContext());
 		FCMPlugin.sendPushPayload(data);
 
         finish();

--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -35,7 +35,6 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         // message, here is where that should be initiated. See sendNotification method below.
         Log.d(TAG, "==> MyFirebaseMessagingService onMessageReceived");
 		
-        setBadgeCount(remoteMessage);
 		if( remoteMessage.getNotification() != null){
 			Log.d(TAG, "\tNotification Title: " + remoteMessage.getNotification().getTitle());
 			Log.d(TAG, "\tNotification Message: " + remoteMessage.getNotification().getBody());
@@ -56,15 +55,6 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
     }
     // [END receive_message]
 
-    private void setBadgeCount(RemoteMessage remoteMessage){
-        try {
-            int badgeCount = Integer.parseInt(remoteMessage.getData().get("badge"));
-            ShortcutBadger.applyCountOrThrow(getApplicationContext(), badgeCount);
-            Log.d(TAG, "showBadge worked!");
-        } catch (ShortcutBadgeException e) {
-            Log.e(TAG, "showBadge failed: " + e.getMessage());
-        }
-    }
     /**
      * Create and show a simple notification containing the received FCM message.
      *

--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -14,8 +14,6 @@ import java.util.HashMap;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
-import me.leolin.shortcutbadger.ShortcutBadgeException;
-import me.leolin.shortcutbadger.ShortcutBadger;
 /**
  * Created by Felipe Echanique on 08/06/2016.
  */
@@ -50,6 +48,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                 Log.d(TAG, "\tKey: " + key + " Value: " + value);
 				data.put(key, value);
         }
+        BadgeHelper.setBadgeCount((String)data.get(BadgeHelper.CONST_BADGE_KEY), getApplicationContext());
 		
 		Log.d(TAG, "\tNotification Data: " + data.toString());
         FCMPlugin.sendPushPayload( data );

--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.ShortcutBadger;
 /**
  * Created by Felipe Echanique on 08/06/2016.
  */
@@ -35,6 +37,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         // message, here is where that should be initiated. See sendNotification method below.
         Log.d(TAG, "==> MyFirebaseMessagingService onMessageReceived");
 		
+        setBadgeCount(remoteMessage);
 		if( remoteMessage.getNotification() != null){
 			Log.d(TAG, "\tNotification Title: " + remoteMessage.getNotification().getTitle());
 			Log.d(TAG, "\tNotification Message: " + remoteMessage.getNotification().getBody());
@@ -54,6 +57,15 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
     }
     // [END receive_message]
 
+    private void setBadgeCount(RemoteMessage remoteMessage){
+        try {
+            int badgeCount = Integer.parseInt(remoteMessage.getData().get("badge"));
+            ShortcutBadger.applyCountOrThrow(getApplicationContext(), badgeCount);
+            Log.d(TAG, "showBadge worked!");
+        } catch (ShortcutBadgeException e) {
+            Log.e(TAG, "showBadge failed: " + e.getMessage());
+        }
+    }
     /**
      * Create and show a simple notification containing the received FCM message.
      *


### PR DESCRIPTION
@fechanique, please review this.

## Why? 
This is a big pain to support badge count(e.g. iOS shows badge count i.e. the number of unread msg just above app icon) for android mobile with Cordova FCM plugin, to do so, we have to use [this library](https://github.com/leolin310148/ShortcutBadger) separately. So why not include that library directly here, so that other users can benefit from this. 

## What
I have added code, that enables badge count in android mobiles. I have used [this](https://github.com/leolin310148/ShortcutBadger) library which adds the badge to app icon, that works in specific mobiles ( such as Sony, Samsung, Asus, HTC etc. ). 

## How
You need to include "badge: XX" in the data part of notification payload in server side code. This is because, when you send the notification, the "badge" key inside notification is not meaningful to android FCM library, they don't get/deserialize the value in android code. So you have to include badge in the data part of notification payload. This issue with firebase is mentioned [here](https://github.com/firebase/quickstart-android/issues/85).

## Example
 I have also created a sample project, that uses my version of fcm-plugin ( Pull request changes). Here is the link to that [project](https://github.com/arindamnayak/cordova-fcm-badge-test).
This is how it will look. 
![example](https://camo.githubusercontent.com/618b29ccb20fb2a69fe54d5cf43e3c9c81601052/68747470733a2f2f7261772e6769746875622e636f6d2f6c656f6c696e3331303134382f53686f72746375744261646765722f6d61737465722f73637265656e73686f74732f73735f73616d73756e672e706e67)


## Detailed explanation
As per [FCM document](https://firebase.google.com/docs/cloud-messaging/android/receive#sample-receive), when you send notification+data, onMessageReceived will not work if the app is in the background. FCM will only show notification in the system bar, and on tapping the notification, onMessageReceived will be called. But when you send only data, onMessageReceived will be called, and that is why badge will be updated. For more help on FCM document, visit [this](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages).

#### Note: This will work for [specific](https://github.com/leolin310148/ShortcutBadger#supported-launchers) android mobiles. 

There are 3 cases to make it work (the badge count on the icon). Anyway notification works for all, but for badge here are the cases.
- ##### App in the foreground.
Just send the message in request payload, include "badge" in data with the required count. It will show directly. Here is the [sample payload](https://pastebin.com/ZJzznZ7n).
- #####  App is background - case -1
Repeat above step, on opening notification, it will update badge count in-app.
- #####  App is background - case -2
Now while sending a notification, send only data part not notification part. This way it will directly update badge count. Here is the [sample payload](https://pastebin.com/wybdzvyv).

## Alternative

You can intercept notification using notification service listener, the link for google document is [here](https://developer.android.com/reference/android/service/notification/NotificationListenerService.html). But this works for android version KITKAT onwards and for below, you can intercept using AccessbilityService. I have tried former one with "NotificationListenerService". I faced one issue, by default the Cordova app is not able to intercept notification, I need to enable in "notification access" in setting option. But here, you neither get badge value from "notification" nor badge from "data" part of request payload, you only get package name, title, text, icons etc.. The other option is to somehow pass badge count in the title with some delimiter separated, and parse it on receiving, then show actual title and use the badge. Again, for android you can not preprocess notification i.e. you can't manipulate once received. [This forum](http://stackoverflow.com/questions/29877300/handling-status-bar-notification-before-it-is-displayed) explains same. So, we **can not** opt for this alternative.

## Conclusion

To show badge count in app icon, we need this PR changes or get the merged version of cordova-fcm-plugin. Notification payload([sample one](https://pastebin.com/wybdzvyv)) request has to contain badge in the data part of JSON. To ensure it works for all scenario, just send a separate call which has only data part.