### PR TITLE
Update resource-file path

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -92,7 +92,7 @@
 			<string>production</string>
 		</config-file>
 		
-		<resource-file src="src/ios/GoogleService-Info.plist" target="Resources/GoogleService-Info.plist" />
+		<resource-file src="src/ios/GoogleService-Info.plist" target="GoogleService-Info.plist" />
 		
         <header-file src="src/ios/FCMPlugin.h" />
         <source-file src="src/ios/FCMPlugin.m" />


### PR DESCRIPTION
`cordova-ios@4.4.0` Seems to change the way the `target` attribute works in `resource-file`. As a result, if I install the plugin as-is my `GoogleService-Info.plist` file ends up in `platforms/ios/<AppName>/Resources/Resources/GoogleService-Info.plist` instead of `platforms/ios/<AppName>/Resources/GoogleService-Info.plist`.

This PR fixes the problem resulting in the latter.

Suggested semver major since it would potentially break on older versions of `cordova-ios` (haven't tested)