### PR TITLE
apply plugin within ext.postBuildExtras block

### DIFF
--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -8,6 +8,11 @@ buildscript {
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }
+
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+
+ext.postBuildExtras = {
+    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+}
+


### PR DESCRIPTION
By performing `apply plugin` within `ext.postBuildExtras` block, other plugins can have the opportunity to provide their own `play-services` dependency overrides within their own `build-extras.gradle`.

Providing a `build-extras.gradle` allows one's Cordova app to have the **final word** on `play-services` dependencies to **resolve conflicts with other plugins**.

I am the author of one these plugins, [cordova-background-geolocation-lt](https://github.com/transistorsoft/cordova-background-geolocation-lt), which conflicts with `cordova-plugin-fcm`.

This method of providing your application's own custom `build-extras.gradle` goes like this:

**Step 1.**  In your application's `config.xml`, define a [`<hook />` script](https://github.com/transistorsoft/cordova-background-geolocation-SampleApp/blob/master/config.xml#L18)

*`config.xml`*
```xml
<platform name="android">
    <hook src="scripts/android/copyGradleBuildExtras.js" type="before_build" />
    .
    .
    .
</platform>
```
**Step 2.** Create file [`scripts/android/copyGradleBuildExtras.js`](https://github.com/transistorsoft/cordova-background-geolocation-SampleApp/blob/master/scripts/android/copyGradleBuildExtras.js)

*`scripts/android/copyBuildExtras.js`*
```javascript
var fs = require ('fs');
var path = require('path');

var sourcePath = path.resolve(__dirname, 'build-extras.gradle');
var destPath = path.resolve(process.cwd(), 'platforms', 'android', 'build-extras.gradle');

// cp scripts/android/build-extras.gradle platforms/android/build-extras.gradle
fs.createReadStream(sourcePath).pipe(fs.createWriteStream(destPath));
```

**Step 3.**  [Define your custom `scripts/android/build-extras.gradle` overrides](https://github.com/transistorsoft/cordova-background-geolocation-SampleApp/blob/master/scripts/android/build-extras.gradle)

This file allows your app to have the **last word** on any gradle dependencies -- **no more need to fork plugins** to "pin" `play-services` version.  (insert your own desired `play-services` version, I chose latest `11.0.2`, but you can choose to pin any desired version (the version **must be the same for each dependency**)

*`scripts/android/build-extras.gradle`*
```gradle
ext.postBuildExtras {
    dependencies {
        // These are the play-services dependencies required by cordova-background-geolocation
        compile ("com.google.android.gms:play-services-base:11.0.2") {
            force = true;
    	}
    	compile ("com.google.android.gms:play-services-location:11.0.2") {
            force = true;
    	}
    
    	// These are the cordova-plugin-fcm dependency overrides
    	compile ("com.google.firebase:firebase-core:11.0.2") {
            force = true
    	}
    	compile ("com.google.firebase:firebase-messaging:11.0.2") {
            force = true
    	}
      
        /* uncomment when using maps (eg: cordova-plugin-googlemaps)
        compile ("com.google.android.gms:play-services-maps:11.0.2") {
            force = true;
        }
        */

        /* uncomment when using firebase-messaging (eg: phonegap-plugin-push)
        compile ("com.google.firebase:firebase-messaging:11.0.2"), {
            force: true;
        }
        */
    }       
}
```
I implemented this method by following the Cordova Guide [Setting Gradle Properties](https://cordova.apache.org/docs/en/latest/guide/platforms/android/#setting-gradle-properties)
