### PR TITLE
Don't try to configure already configured app

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -95,7 +95,9 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     }
 
     // [START configure_firebase]
-    [FIRApp configure];
+    if(![FIRApp defaultApp]) {
+        [FIRApp configure];
+    }
     // [END configure_firebase]
     // Add observer for InstanceID token refresh callback.
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)


### PR DESCRIPTION
This prevents an error when used together with another Firebase Cordova plugins which may have already configured the Firebase app.