### PR TITLE
Call configure only if defaultApp is null

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -95,7 +95,9 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     }
 
     // [START configure_firebase]
-    [FIRApp configure];
+    if([FIRApp defaultApp] == nil) {
+        [FIRApp configure];
+    }
     // [END configure_firebase]
     // Add observer for InstanceID token refresh callback.
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)


### PR DESCRIPTION
In some cases the app might be already configured and calling configure twice crash the app with this error

`*** Terminating app due to uncaught exception 'com.firebase.core', reason: 'Default app has already been configured.`

Closes #58