### PR TITLE
Update FCMPlugin.gradle

### DIFF
--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -10,4 +10,5 @@ buildscript {
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+// as for the last update of google services to version 12 this line will cause a build error
+// apply plugin: com.google.gms.googleservices.GoogleServicesPlugin


### PR DESCRIPTION
as for the last update of google services to version 12 this line
`apply plugin: com.google.gms.googleservices.GoogleServicesPlugin`
 will cause the following build error :
BUILD FAILED Error: more than one library with package name 'com.google.android.gms.license

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fechanique/cordova-plugin-fcm/488)
<!-- Reviewable:end -->
