### PR TITLE
Fix strings.xml path

### DIFF
--- a/scripts/fcm_config_files_process.js
+++ b/scripts/fcm_config_files_process.js
@@ -43,7 +43,7 @@ var PLATFORM = {
             ANDROID_DIR + '/assets/www/google-services.json',
             'www/google-services.json'
         ],
-        stringsXml: ANDROID_DIR + '/res/values/strings.xml'
+        stringsXml: ANDROID_DIR + '/app/src/main/res/values/strings.xml'
     }
 };
 


### PR DESCRIPTION
When adding plugin, it 's trying to find `strings.xml` in a wrong path:

```
Installing "cordova-plugin-fcm" for ios

		Cordova FCM plugin v2.1.2 installed
		For more details visit https://github.com/fechanique/cordova-plugin-fcm
	
{ Error: ENOENT: no such file or directory, open 'platforms/android/res/values/strings.xml'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.readFileSync (fs.js:551:33)
    at updateStringsXml (/Users/gustavo/Github/copay-v4/plugins/cordova-plugin-fcm/scripts/fcm_config_files_process.js:60:22)
    at copyKey (/Users/gustavo/Github/copay-v4/plugins/cordova-plugin-fcm/scripts/fcm_config_files_process.js:97:29)
    at Object.<anonymous> (/Users/gustavo/Github/copay-v4/plugins/cordova-plugin-fcm/scripts/fcm_config_files_process.js:55:5)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'platforms/android/res/values/strings.xml' }
```
