### PR TITLE
Fixing deprecated FirebaseInstanceIdService

### DIFF
--- a/src/android/MyFirebaseInstanceIDService.java
+++ b/src/android/MyFirebaseInstanceIDService.java
@@ -2,24 +2,24 @@ package com.gae.scaffolder.plugin;
 
 import android.util.Log;
 
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.FirebaseInstanceIdService;
+// import com.google.firebase.iid.FirebaseInstanceId;
+// import com.google.firebase.iid.FirebaseInstanceIdService;
 
 /**
  * Created by Felipe Echanique on 08/06/2016.
  */
-public class MyFirebaseInstanceIDService extends FirebaseInstanceIdService {
+public class MyFirebaseInstanceIDService { // extends FirebaseInstanceIdService {
 
     private static final String TAG = "FCMPlugin";
 
-    @Override
-    public void onTokenRefresh(){
-        // Get updated InstanceID token.
-        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-        Log.d(TAG, "Refreshed token: " + refreshedToken);
-		FCMPlugin.sendTokenRefresh( refreshedToken );
+    // @Override
+    // public void onTokenRefresh(){
+    //     // Get updated InstanceID token.
+    //     String refreshedToken = FirebaseInstanceId.getInstance().getToken();
+    //     Log.d(TAG, "Refreshed token: " + refreshedToken);
+	// 	FCMPlugin.sendTokenRefresh( refreshedToken );
 
-        // TODO: Implement this method to send any registration to your app's servers.
-        //sendRegistrationToServer(refreshedToken);
-    }
+    //     // TODO: Implement this method to send any registration to your app's servers.
+    //     //sendRegistrationToServer(refreshedToken);
+    // }
 }

--- a/src/android/MyFirebaseMessagingService.java
+++ b/src/android/MyFirebaseMessagingService.java
@@ -82,4 +82,14 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
         notificationManager.notify(0 /* ID of notification */, notificationBuilder.build());
     }
+
+    @Override
+    public void onNewToken(String refreshedToken) {
+        super.onNewToken(refreshedToken);
+        //Log.e("TOKEN",refreshedToken);
+        //String refreshedToken = FirebaseInstanceId.getInstance().getToken();
+        Log.d(TAG, "Refreshed token: " + refreshedToken);
+		FCMPlugin.sendTokenRefresh( refreshedToken );
+    }
+
 }


### PR DESCRIPTION
This fix include deprecateds: 

Class:
FirebaseInstanceIdService

And method:
FirebaseInstanceId.getInstance().getToken();

Tested and works fine.